### PR TITLE
Complete Overhaul

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -27,22 +27,17 @@ Session.store = function _psStore(type, key, value) {
     this.psaKeyList = _.without(this.psaKeyList, key);
     delete this.psKeys[key];
     delete this.psaKeys[key];
+    
+    if (value===undefined || value===null || type=='temporary') {
+      value==null;
 
-    switch (type) {
-
-      case 'temporary':
-        value = null;
-        break;
-
-      case 'persistent':
-        this.psKeys[key] = EJSON.stringify(value);
-        this.psKeyList = _.union(this.psKeyList, [key]);
-        break;
-
-      case 'authenticated':
-        this.psaKeys[key] = EJSON.stringify(value);
-        this.psaKeyList = _.union(this.psaKeyList, [key]);
-        break;
+    } else if (type=='persisent') {
+      this.psKeys[key] = EJSON.stringify(value);
+      this.psKeyList = _.union(this.psKeyList, [key]);
+     
+    } else if (type=='authenticated') {
+      this.psaKeys[key] = EJSON.stringify(value);
+      this.psaKeyList = _.union(this.psaKeyList, [key]);
     }
 
     amplify.store('__PSKEYS__', this.psKeyList);
@@ -67,7 +62,7 @@ Session.set = function _psSet(key, value, persist, auth) {
   this.old_set(key, value);
   var type = 'temporary';
   if (persist || (persist===undefined && (default_method=='persistent' || default_method=='authenticated'))) {
-    if (auth || (auth==undefined && default_method=='authenticated')) {
+    if (auth || (persist===undefined && auth===undefined && default_method=='authenticated')) {
       type = 'authenticated';
     } else {
       type = 'persistent';
@@ -146,8 +141,7 @@ Session.clearAuth = function _psClearAuth() {
 // === UPDATE ===
 // updates the value of a session var without changing its type
 Session.update = function _psUpdate(key, value) {
-  var persist = false;
-  var auth = false;
+  var persist, auth;
   if ( _.indexOf(this.psaKeyList, key) >= 0 ) { auth = true; }
   if ( auth || _.indexOf(this.psKeyList, key) >= 0 ) { persist = true; }
   this.set(key, value, persist, auth);


### PR DESCRIPTION
Completely overhauled the management of persistent session. There are now 3 spaces: temporary (matches current Meteor implementation), persistent (data is stored in localStorage until cleared), and authenticated (data is stored in localStorage until cleared AND is cleared automatically when a user logs out). Because you can now determine which variables to clear on logout at the time of their creation, I ditched the associated setting.

There is a new setting: default_method, which dictates which method to use when calling Session.set(). You can always specify exactly which method to use when saving (overriding the default_method) by using the correct call.

SETTING SESSION VARIABLES:
using the basic set() commands will change the type of a session var if just updating the value
- Session.set(key, value) <--- store a session var according to the default_method
- Session.setTemp(key, value) <--- store a session var without persistence
- Session.setPersistent(key, value) <--- store a session var with localStorage
- Session.setAuth(key, value) <--- store a session var with localStorage and delete it when the user logs out

++ADDED w/ 2nd COMMIT
UPDATE SESSION VALUES
you can just update the value of an existing session var without changing or knowing its type. (if you call update on an non-existent var, it should be created as a temp var)
- Session.update(key, value)

SET DEFAULT 
all of the set() functions have a setDefault counterpart where the session var will only be created if one doesn't already exist. None of the setDefault() commands will change the type of an existing session var.
- Session.setDefault(key, value)
- Session.setDefaultTemp(key, value)
- Session.setDefaultPersistent(key, value)
- Session.setDefaultAuth(key, value)

CHANGE TYPES
Use these commands to change a session var into a particular type
- Session.makeTemp(key)
- Session.makePersistent(key)
- Session.makeAuth(key)

CLEAR VALUES
- Session.clear() <--- destroys all session vars of all types
- Session.clear(key) <--- destroys a single session var
- Session.clearTemp() <--- destroys all temp session vars
- Session.clearPersistent() <--- destroys all persistent session vars
- Session.clearAuth() <--- destroys all auth session vars

OTHER
These work the same as the current Meteor implementation 
- Session.get(key)
- Session.equals(key, value)
