### PR TITLE
Changed default_method to "temporary"

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -5,7 +5,7 @@ Session.psaKeys = {};
 Session.psaKeyList = [];
 
 // initialize default method setting
-var default_method = 'persistent'; // valid options: 'temporary', 'persistent', 'authenticated'
+var default_method = 'temporary'; // valid options: 'temporary', 'persistent', 'authenticated'
 if (Meteor.settings &&
     Meteor.settings.public &&
     Meteor.settings.public.persistent_session) {


### PR DESCRIPTION
This fixes #15. I figured out what it was. I'm generating a lot of session variables with randomized UUID names. This is fine since on refresh they're cleared and have no impact. The issue is that persistent-session has the [following line](https://github.com/okgrow/meteor-persistent-session/blob/master/lib/persistent_session.js#L8):
```
var default_method = 'persistent';
```
According to the docs, this should be set to temporary. At the moment, all calls to `Session.set()` will be storing the value in the persistent session which I believe is unintended.