### PR TITLE
Support `Session.set` taking an object parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Setting Session Values
 * `Session.setAuth(key, value)`
   * stores a authenticated session variable (persistent + automatic deletion)
 
+As of 3.3, you can use an object to set multiple values at once:
+
+```javasript
+Session.setPersistent({foo: "foo", bar: "bar"});
+```
+
+This works with all of the `set*` methods. All key/values set as an object
+will have the same type of scoping (persistent/auth/temporary).
+
 Updating Session Values
 -----------------------
 

--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -75,7 +75,16 @@ Session.get = function _psGet(key) {
 // === SET ===
 // defaults to a persistent, non-authenticated variable
 Session.old_set = Session.set;
-Session.set = function _psSet(key, value, persist, auth) {
+Session.set = function _psSet(keyOrObject, value, persist, auth) {
+
+  // Taken from https://github.com/meteor/meteor/blob/107d858/packages/reactive-dict/reactive-dict.js
+  if ((typeof keyOrObject === 'object') && (value === undefined)) {
+    this._psSetObject(keyOrObject, persist, auth);
+    return;
+  }
+
+  var key = keyOrObject;
+
   this.old_set(key, value);
   var type = 'temporary';
   if (persist || (persist===undefined && (default_method=='persistent' || default_method=='authenticated'))) {
@@ -88,22 +97,30 @@ Session.set = function _psSet(key, value, persist, auth) {
   Session.store(type, key, value);
 };
 
+Session._psSetObject = function _psSetObject(object, persist, auth) {
+  var self = this;
+
+  _.each(object, function (value, key){
+    self.set(key, value, persist, auth);
+  });
+};
+
 // === SET TEMPORARY ===
 // alias to Session.set(); sets a non-persistent variable
-Session.setTemp = function _psSetTemp(key, value) {
-  this.set(key, value, false, false);
+Session.setTemp = function _psSetTemp(keyOrObject, value) {
+  this.set(keyOrObject, value, false, false);
 };
 
 // === SET PERSISTENT ===
 // alias to Session.set(); sets a persistent variable
-Session.setPersistent = function _psSetPersistent(key, value) {
-  this.set(key, value, true, false);
+Session.setPersistent = function _psSetPersistent(keyOrObject, value) {
+  this.set(keyOrObject, value, true, false);
 };
 
 // === SET AUTHENTICATED ===
 // alias to Session.set(); sets a persistent variable that will be removed on logout
-Session.setAuth = function _psSetAuth(key, value) {
-  this.set(key, value, true, true);
+Session.setAuth = function _psSetAuth(keyOrObject, value) {
+  this.set(keyOrObject, value, true, true);
 };
 
 // === MAKE TEMP / PERSISTENT / AUTH ===


### PR DESCRIPTION
So now you can do `Session.setPersistent({foo: "foo", bar: "bar"});`