### PR TITLE
Don't try to parse values that weren't explicitly set through Session

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -59,6 +59,11 @@ Session.get = function _psGet(key) {
   var val = this.old_get(key);
   var psVal;
   var unparsedPsVal = Session.store('get', key);
+  if (!_.contains(this.psKeyList, key) && !_.contains(this.psaKeyList, key)) {
+    // This value was not set by Session previously, so we can't assume it's
+    // in EJSON format.
+    return unparsedPsVal;
+  }
   if (unparsedPsVal !== undefined) {
     psVal = EJSON.parse(Session.store('get', key));
   }


### PR DESCRIPTION
Fixes #24

This is encountered when a variable is set using `amplify.store` but
then accessed via `Session.get`.