### PR TITLE
Bump to 0.4.0, resolve github issues, make testable

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -1,32 +1,124 @@
-/*
- * Used to determine if we need to migrate how the data is stored.
- * Each time the data format changes, increment this number.
- */
-var PSA_DATA_VERSION = 1;
+PersistentSession = function (dictName) {
+  if (_.isString(dictName)) {
+    this._dictName = dictName;
 
-// === INITIALIZE KEY TRACKING ===
-Session.psKeys = {};
-Session.psKeyList = [];
-Session.psaKeys = {};
-Session.psaKeyList = [];
+    // when "session", use the existing dict
+    if (dictName == "session") {
+      this._dictName = ""   // we don't need a name for session
+      this._dict = Session; // we also want to use the global (incase something was set previously)
 
-// initialize default method setting
-var default_method = 'temporary'; // valid options: 'temporary', 'persistent', 'authenticated'
-if (Meteor.settings &&
-    Meteor.settings.public &&
-    Meteor.settings.public.persistent_session) {
-  default_method = Meteor.settings.public.persistent_session.default_method;
-}
+    // not session? create a new dict
+    } else {
+      this._dict = new ReactiveDict(dictName);
+    }
+
+  } else {
+    throw new Error("dictName must be a string");
+  }
+
+
+  /*
+   * Used to determine if we need to migrate how the data is stored.
+   * Each time the data format changes, increment this number.
+   */
+  var PSA_DATA_VERSION = 1;
+
+  // === INITIALIZE KEY TRACKING ===
+  this.psKeys     = {};
+  this.psKeyList  = [];
+  this.psaKeys    = {};
+  this.psaKeyList = [];
+
+  // initialize default method setting
+  this.default_method = 'temporary'; // valid options: 'temporary', 'persistent', 'authenticated'
+  if (Meteor.settings &&
+      Meteor.settings.public &&
+      Meteor.settings.public.persistent_session) {
+    this.default_method = Meteor.settings.public.persistent_session.default_method;
+  }
+
+
+  var self = this;
+
+  // === HOUSEKEEPING ===
+  /*
+   * Converts previously stored values into EJSON compatible formats.
+   */
+  function migrateToEJSON() {
+    if (amplify.store('__PSDATAVERSION__' + self._dictName) >= PSA_DATA_VERSION) {
+      return;
+    }
+
+    var psKeyList = amplify.store('__PSKEYS__' + self._dictName);
+    var psaKeyList = amplify.store('__PSAKEYS__' + self._dictName);
+
+    _.each([psKeyList, psaKeyList], function(list) {
+      _.each(list, function(key) {
+        amplify.store(key, EJSON.stringify(amplify.store(key)));
+      });
+    });
+
+    amplify.store('__PSDATAVERSION__' + self._dictName, PSA_DATA_VERSION);
+  };
+
+  if (Meteor.isClient) {
+
+    // --- on startup, load persistent data back into meteor session ---
+    Meteor.startup(function(){
+      var val;
+
+      migrateToEJSON();
+
+      // persistent data
+      var psList = amplify.store('__PSKEYS__' + self._dictName);
+      if ( typeof psList == "object" && psList.length!==undefined ) {
+        for (var i=0; i<psList.length; i++) {
+          if (!_.has(self._dict.keys, psList[i])) {
+            val = self.get(psList[i]);
+            self.set(psList[i], val, true, false);
+          }
+        }
+      }
+
+      // authenticated data
+      var psaList = amplify.store('__PSAKEYS__' + self._dictName);
+      if ( typeof psaList == "object" && psaList.length!==undefined ) {
+        for (var i=0; i<psaList.length; i++) {
+          if (!_.has(self._dict.keys, psaList[i])) {
+            val = self.get(psaList[i]);
+            self.setAuth(psaList[i], val, true, true);
+          }
+        }
+      }
+
+    });
+
+  };
+
+  Tracker.autorun(function () {
+    // lazy check for accounts-base
+    if (Meteor.userId) {
+      var userId = Meteor.userId()
+      if (userId) {
+        // user is logged in, leave session in tacted
+      } else {
+        // user is unset, clear authencated keys
+        self.clearAuth()
+      }
+    }
+  });
+
+  return this;
+};
 
 // === LOCAL STORAGE INTERACTION ===
-Session.store = function _psStore(type, key, value) {
-
-  this.psKeyList  = amplify.store('__PSKEYS__') || [];
-  this.psaKeyList = amplify.store('__PSAKEYS__')|| [];
+PersistentSession.prototype.store = function _psStore(type, key, value) {
+  // use dict name for uniqueness
+  this.psKeyList  = amplify.store('__PSKEYS__' + this._dictName) || [];
+  this.psaKeyList = amplify.store('__PSAKEYS__' + this._dictName)|| [];
 
   if (type == 'get') {
-    return amplify.store(key);
-
+    return amplify.store(this._dictName + key);
   } else {
 
     this.psKeyList  = _.without(this.psKeyList, key);
@@ -48,20 +140,24 @@ Session.store = function _psStore(type, key, value) {
 
     amplify.store('__PSKEYS__', this.psKeyList);
     amplify.store('__PSAKEYS__', this.psaKeyList);
-    amplify.store(key, EJSON.stringify(value));
+    amplify.store(this._dictName + key, EJSON.stringify(value));
   }
-
 };
 
+
 // === GET ===
-Session.old_get = Session.get;
-Session.get = function _psGet(key) {
+// keep for backwards compability, redirect to this._dict
+PersistentSession.prototype.old_get = function (/* arguments */){
+  return this._dict.get.apply(this._dict, arguments);
+};
+PersistentSession.prototype.get = function _psGet(key) {
   var val = this.old_get(key);
   var psVal;
-  var unparsedPsVal = Session.store('get', key);
+  var unparsedPsVal = this.store('get', key);
   if (unparsedPsVal !== undefined) {
-    psVal = EJSON.parse(Session.store('get', key));
+    psVal = EJSON.parse(this.store('get', key));
   }
+
   /*
    * We can't do `return psVal || val;` here, as when psVal = undefined and
    * val = 0, it will return undefined, even though 0 is the correct value.
@@ -72,10 +168,13 @@ Session.get = function _psGet(key) {
   return psVal;
 };
 
+
 // === SET ===
-// defaults to a persistent, non-authenticated variable
-Session.old_set = Session.set;
-Session.set = function _psSet(keyOrObject, value, persist, auth) {
+PersistentSession.prototype.old_set = function (/* arguments */){
+  // defaults to a persistent, non-authenticated variable
+  return this._dict.set.apply(this._dict, arguments);
+};
+PersistentSession.prototype.set = function _psSet(keyOrObject, value, persist, auth) {
 
   // Taken from https://github.com/meteor/meteor/blob/107d858/packages/reactive-dict/reactive-dict.js
   if ((typeof keyOrObject === 'object') && (value === undefined)) {
@@ -87,17 +186,17 @@ Session.set = function _psSet(keyOrObject, value, persist, auth) {
 
   this.old_set(key, value);
   var type = 'temporary';
-  if (persist || (persist===undefined && (default_method=='persistent' || default_method=='authenticated'))) {
-    if (auth || (persist===undefined && auth===undefined && default_method=='authenticated')) {
+  if (persist || (persist===undefined && (this.default_method=='persistent' || this.default_method=='authenticated'))) {
+    if (auth || (persist===undefined && auth===undefined && this.default_method=='authenticated')) {
       type = 'authenticated';
     } else {
       type = 'persistent';
     }
   }
-  Session.store(type, key, value);
+  this.store(type, key, value);
 };
 
-Session._psSetObject = function _psSetObject(object, persist, auth) {
+PersistentSession.prototype._psSetObject = function _psSetObject(object, persist, auth) {
   var self = this;
 
   _.each(object, function (value, key){
@@ -106,75 +205,139 @@ Session._psSetObject = function _psSetObject(object, persist, auth) {
 };
 
 // === SET TEMPORARY ===
-// alias to Session.set(); sets a non-persistent variable
-Session.setTemp = function _psSetTemp(keyOrObject, value) {
+// alias to .set(); sets a non-persistent variable
+PersistentSession.prototype.setTemp = function _psSetTemp(keyOrObject, value) {
   this.set(keyOrObject, value, false, false);
 };
 
 // === SET PERSISTENT ===
-// alias to Session.set(); sets a persistent variable
-Session.setPersistent = function _psSetPersistent(keyOrObject, value) {
+// alias to .set(); sets a persistent variable
+PersistentSession.prototype.setPersistent = function _psSetPersistent(keyOrObject, value) {
   this.set(keyOrObject, value, true, false);
 };
 
 // === SET AUTHENTICATED ===
-// alias to Session.set(); sets a persistent variable that will be removed on logout
-Session.setAuth = function _psSetAuth(keyOrObject, value) {
+// alias to .set(); sets a persistent variable that will be removed on logout
+PersistentSession.prototype.setAuth = function _psSetAuth(keyOrObject, value) {
   this.set(keyOrObject, value, true, true);
 };
 
+
 // === MAKE TEMP / PERSISTENT / AUTH ===
 // change the type of session var
-Session.makeTemp = function _psMakeTemp(key) {
+PersistentSession.prototype.makeTemp = function _psMakeTemp(key) {
   this.store('temporary', key);
 };
-Session.makePersistent = function _psMakePersistent(key) {
+PersistentSession.prototype.makePersistent = function _psMakePersistent(key) {
   var val = this.get(key);
   this.store('persistent', key, val);
 };
-Session.makeAuth = function _psMakeAuth(key) {
+PersistentSession.prototype.makeAuth = function _psMakeAuth(key) {
   var val = this.get(key);
   this.store('authenticated', key, val);
 };
 
+
+
 // === CLEAR ===
-Session.clear = function _psClear(key, list) {
+PersistentSession.prototype.old_clear = function (/* arguments */){
+  return this._dict.clear.apply(this._dict, arguments);
+};
+PersistentSession.prototype.clear = function _psClear(key, list) {
+  var self = this;
+  var oldKeys = self._dict.keys;
 
-  // remove all keys with Session.clear();
-  if (key === undefined) {
-    if (list===undefined) { list = this.keys; }
-    for (var k in list) {
-      this.set(k, undefined, false, false);
-    }
-
-  // remove a single key with Session.clear('key');
+  if ((key === undefined) && (list === undefined)) {
+    list = oldKeys;
+  } else if (!(key === undefined)) {
+    list = [key]
   } else {
-    this.set(key, undefined, false, false);
+    // list = list
   }
 
+  // okay, if it was an array of keys, find the old key pairings
+  if (_.isArray(list)){
+    var oldList = list;
+    var list = {}
+    _.each(oldList, function (key) {
+      list[key] = oldKeys[key];
+    });
+  }
+
+  _.each(list, function(value, akey) {
+    self.set(akey, undefined, false, false);
+  });
 };
+
+
+// more or less how it's implemented in reactive dict, but add support for removing single or arrays of keys
+PersistentSession.prototype.clear = function _psClear(key, list) {
+  var self = this;
+  var oldKeys = self._dict.keys;
+
+  if ((key === undefined) && (list === undefined)) {
+    list = oldKeys;
+  } else if (!(key === undefined)) {
+    list = [key]
+  } else {
+    // list = list
+  }
+
+  // okay, if it was an array of keys, find the old key pairings for reactivity
+  if (_.isArray(list)){
+    var oldList = list;
+    var list = {}
+    _.each(oldList, function (key) {
+      list[key] = oldKeys[key];
+    });
+  }
+
+  // helper from reactive-dict
+  var changed = function (v) {
+    v && v.changed();
+  };
+
+  _.each(list, function(value, akey) {
+    self.set(akey, undefined, false, false);
+
+    changed(self._dict.keyDeps[akey]);
+    changed(self._dict.keyValueDeps[akey][value]);
+    changed(self._dict.keyValueDeps[akey]['undefined']);
+
+    delete self._dict.keys[akey]; // remove the key
+  });
+
+  // reactive-dict 1.1.0+
+  if (self._dict.allDeps) {
+    self._dict.allDeps.changed();
+  }
+};
+
 
 // === CLEAR TEMP ===
 // clears all the temporary keys
-Session.clearTemp = function _psClearTemp() {
-  this.clear(undefined, _.keys(_.omit(this.keys, this.psKeys, this.psaKeys)));
+PersistentSession.prototype.clearTemp = function _psClearTemp() {
+  this.clear(undefined, _.keys(_.omit(this._dict.keys, this.psKeys, this.psaKeys)));
 };
 
 // === CLEAR PERSISTENT ===
 // clears all persistent keys
-Session.clearPersistent = function _psClearPersistent() {
+PersistentSession.prototype.clearPersistent = function _psClearPersistent() {
   this.clear(undefined, this.psKeys);
 };
 
 // === CLEAR AUTH ===
 // clears all authenticated keys
-Session.clearAuth = function _psClearAuth() {
+PersistentSession.prototype.clearAuth = function _psClearAuth() {
   this.clear(undefined, this.psaKeys);
 };
 
+
+
+
 // === UPDATE ===
 // updates the value of a session var without changing its type
-Session.update = function _psUpdate(key, value) {
+PersistentSession.prototype.update = function _psUpdate(key, value) {
   var persist, auth;
   if ( _.indexOf(this.psaKeyList, key) >= 0 ) { auth = true; }
   if ( auth || _.indexOf(this.psKeyList, key) >= 0 ) { persist = true; }
@@ -182,89 +345,56 @@ Session.update = function _psUpdate(key, value) {
 };
 
 // === SET DEFAULT ===
-Session.old_setDefault = Session.setDefault;
-Session.setDefault = function _psSetDefault(key, value, persist, auth) {
-  if ( this.get(key) === undefined) {
-    this.set(key, value, persist, auth);
+PersistentSession.prototype.old_setDefault = function (/* arguments */){
+  return this._dict.setDefault.apply(this._dict, arguments);
+};
+PersistentSession.prototype.setDefault = function _psSetDefault(keyOrObject, value, persist, auth) {
+  var self = this;
+
+  if (_.isObject(keyOrObject)) {
+    _.each(keyOrObject, function(value, key) {
+      self._dict.setDefault(key, value, persist, auth);
+    });
+    return;
+  }
+
+  // TODO: Handle objects
+  if ( this.get(keyOrObject) === undefined) {
+    this.set(keyOrObject, value, persist, auth);
   }
 };
 
 // === SET DEFAULT TEMP ===
-Session.setDefaultTemp = function _psSetDefaultTemp(key, value) {
-  this.setDefault(key, value, false, false);
+PersistentSession.prototype.setDefaultTemp = function _psSetDefaultTemp(keyOrObject, value) {
+
+  if (_.isObject(keyOrObject)) {
+    value = undefined; 
+  }
+
+  this.setDefault(keyOrObject, value, false, false);
 };
 
 // === SET DEFAULT PERSISTENT ===
-Session.setDefaultPersistent = function _psSetDefaultPersistent(key, value) {
-  this.setDefault(key, value, true, false);
+PersistentSession.prototype.setDefaultPersistent = function _psSetDefaultPersistent(keyOrObject, value) {
+
+  if (_.isObject(keyOrObject)) {
+    value = undefined; 
+  }
+
+  this.setDefault(keyOrObject, value, true, false);
 };
 
 // === SET DEFAULT AUTH ===
-Session.setDefaultAuth = function _psSetDefaultAuth(key, value) {
-  this.setDefault(key, value, true, true);
+PersistentSession.prototype.setDefaultAuth = function _psSetDefaultAuth(keyOrObject, value) {
+
+  if (_.isObject(keyOrObject)) {
+    value = undefined; 
+  }
+
+  this.setDefault(keyOrObject, value, true, true);
 };
 
 
-// === HOUSEKEEPING ===
 
-/*
- * Converts previously stored values into EJSON compatible formats.
- */
-function migrateToEJSON() {
-  if (amplify.store('__PSDATAVERSION__') >= PSA_DATA_VERSION) {
-    return;
-  }
-
-  var psKeyList = amplify.store('__PSKEYS__');
-  var psaKeyList = amplify.store('__PSAKEYS__');
-
-  _.each([psKeyList, psaKeyList], function(list) {
-    _.each(list, function(key) {
-      amplify.store(key, EJSON.stringify(amplify.store(key)));
-    });
-  });
-
-  amplify.store('__PSDATAVERSION__', PSA_DATA_VERSION);
-}
-
-
-if (Meteor.isClient) {
-
-  // --- on startup, load persistent data back into meteor session ---
-  Meteor.startup(function(){
-    var val;
-
-    migrateToEJSON();
-
-    // persistent data
-    var psList = amplify.store('__PSKEYS__');
-    if ( typeof psList == "object" && psList.length!==undefined ) {
-      for (var i=0; i<psList.length; i++) {
-        if (!_.has(Session.keys, psList[i])) {
-          val = Session.get(psList[i]);
-          Session.set(psList[i], val, true, false);
-        }
-      }
-    }
-
-    // authenticated data
-    var psaList = amplify.store('__PSAKEYS__');
-    if ( typeof psaList == "object" && psaList.length!==undefined ) {
-      for (var i=0; i<psaList.length; i++) {
-        if (!_.has(Session.keys, psaList[i])) {
-          val = Session.get(psaList[i]);
-          Session.setAuth(psaList[i], val, true, true);
-        }
-      }
-    }
-
-  });
-
-  // --- clear authenticated data on logout ---
-  var _logout = Meteor.logout;
-  Meteor.logout = function _psLogout() {
-    Session.clearAuth();
-    _logout.apply(Meteor, arguments);
-  };
-
-}
+// automatically apply PersistentSession to Session
+Session = new PersistentSession("session");

--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -1,3 +1,20 @@
+// helpers: https://github.com/meteor/meteor/blob/devel/packages/reactive-dict/reactive-dict.js#L1-L16
+var stringify = function (value) {
+  if (value === undefined)
+    return 'undefined';
+  return EJSON.stringify(value);
+};
+var parse = function (serialized) {
+  if (serialized === undefined || serialized === 'undefined')
+    return undefined;
+  return EJSON.parse(serialized);
+};
+
+var changed = function (v) {
+  v && v.changed();
+};
+
+
 PersistentSession = function (dictName) {
   if (_.isString(dictName)) {
     this._dictName = dictName;
@@ -5,7 +22,7 @@ PersistentSession = function (dictName) {
     // when "session", use the existing dict
     if (dictName == "session") {
       this._dictName = ""   // we don't need a name for session
-      this._dict = Session; // we also want to use the global (incase something was set previously)
+      this._dict = oldSession; // we also want to use the global (incase something was set previously)
 
     // not session? create a new dict
     } else {
@@ -178,13 +195,11 @@ PersistentSession.prototype.set = function _psSet(keyOrObject, value, persist, a
 
   // Taken from https://github.com/meteor/meteor/blob/107d858/packages/reactive-dict/reactive-dict.js
   if ((typeof keyOrObject === 'object') && (value === undefined)) {
-    this._psSetObject(keyOrObject, persist, auth);
+    this._setObject(keyOrObject, persist, auth);
     return;
   }
 
   var key = keyOrObject;
-
-  this.old_set(key, value);
   var type = 'temporary';
   if (persist || (persist===undefined && (this.default_method=='persistent' || this.default_method=='authenticated'))) {
     if (auth || (persist===undefined && auth===undefined && this.default_method=='authenticated')) {
@@ -194,9 +209,22 @@ PersistentSession.prototype.set = function _psSet(keyOrObject, value, persist, a
     }
   }
   this.store(type, key, value);
+  this.old_set(key, value);
 };
 
-PersistentSession.prototype._psSetObject = function _psSetObject(object, persist, auth) {
+
+// Backwords compat:
+PersistentSession.prototype.all = function _psAll() {
+  this._dict.allDeps.depend();
+  var ret = {};
+  _.each(this._dict.keys, function(value, key) {
+    ret[key] = parse(value);
+  });
+  return ret;
+}
+
+
+PersistentSession.prototype._setObject = function _psSetObject(object, persist, auth) {
   var self = this;
 
   _.each(object, function (value, key){
@@ -204,8 +232,70 @@ PersistentSession.prototype._psSetObject = function _psSetObject(object, persist
   });
 };
 
+PersistentSession.prototype._ensureKey = function _psEnsureKey(key) {
+  var self = this._dict;
+  if (!(key in self.keyDeps)) {
+    self.keyDeps[key] = new Tracker.Dependency;
+    self.keyValueDeps[key] = {};
+  }
+}
+
+// === EQUALS ===
+PersistentSession.prototype.equals = function _psEquals(key, value) {
+
+  // Mongo.ObjectID is in the 'mongo' package
+  var ObjectID = null;
+  if (Package.mongo) {
+    ObjectID = Package.mongo.Mongo.ObjectID;
+  }
+
+  // We don't allow objects (or arrays that might include objects) for
+  // .equals, because JSON.stringify doesn't canonicalize object key
+  // order. (We can make equals have the right return value by parsing the
+  // current value and using EJSON.equals, but we won't have a canonical
+  // element of keyValueDeps[key] to store the dependency.) You can still use
+  // "EJSON.equals(reactiveDict.get(key), value)".
+  //
+  // XXX we could allow arrays as long as we recursively check that there
+  // are no objects
+  if (typeof value !== 'string' &&
+      typeof value !== 'number' &&
+      typeof value !== 'boolean' &&
+      typeof value !== 'undefined' &&
+      !(value instanceof Date) &&
+      !(ObjectID && value instanceof ObjectID) &&
+      value !== null) {
+    throw new Error("ReactiveDict.equals: value must be scalar");
+  }
+  var serializedValue = stringify(value);
+
+  if (Tracker.active) {
+    this._ensureKey(key);
+
+    if (! _.has(this._dict.keyValueDeps[key], serializedValue))
+      this._dict.keyValueDeps[key][serializedValue] = new Tracker.Dependency;
+
+    var isNew = this._dict.keyValueDeps[key][serializedValue].depend();
+    if (isNew) {
+      Tracker.onInvalidate(function () {
+        // clean up [key][serializedValue] if it's now empty, so we don't
+        // use O(n) memory for n = values seen ever
+        if (! this._dict.keyValueDeps[key][serializedValue].hasDependents())
+          delete this._dict.keyValueDeps[key][serializedValue];
+      });
+    }
+  }
+
+  var oldValue = this.get(key);
+
+  return EJSON.equals(oldValue, value);
+};
+
 // === SET TEMPORARY ===
 // alias to .set(); sets a non-persistent variable
+PersistentSession.prototype.setTemporary = function _psSetTemp(keyOrObject, value) {
+  this.set(keyOrObject, value, false, false);
+};
 PersistentSession.prototype.setTemp = function _psSetTemp(keyOrObject, value) {
   this.set(keyOrObject, value, false, false);
 };
@@ -291,11 +381,6 @@ PersistentSession.prototype.clear = function _psClear(key, list) {
       list[key] = oldKeys[key];
     });
   }
-
-  // helper from reactive-dict
-  var changed = function (v) {
-    v && v.changed();
-  };
 
   _.each(list, function(value, akey) {
     self.set(akey, undefined, false, false);
@@ -397,4 +482,5 @@ PersistentSession.prototype.setDefaultAuth = function _psSetDefaultAuth(keyOrObj
 
 
 // automatically apply PersistentSession to Session
-Session = new PersistentSession("session");
+var oldSession = _.clone(Session);
+_.extend(Session, new PersistentSession("session"))

--- a/package.js
+++ b/package.js
@@ -1,13 +1,26 @@
 Package.describe({
   name: "u2622:persistent-session",
-  version: "0.3.5",
+  version: "0.4.0",
   summary: "Persistently store Session data on the client",
   git: "https://github.com/okgrow/meteor-persistent-session"
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('0.9.1'),
-  api.use(['jquery', 'amplify', 'session', 'underscore', 'ejson']);
-  api.export("PersistentSession");
+  api.use(['jquery', 'amplify', 'tracker', 'reactive-dict', 'session', 'underscore', 'ejson']);
   api.addFiles('lib/persistent_session.js', 'client');
+  api.export('PersistentSession', ['client']);
+});
+
+Package.onTest(function (api) {
+  api.use("tinytest");
+  api.use("amplify");
+  api.use("reactive-dict"); // we only need this exposed for testing
+  api.use("u2622:persistent-session");
+
+  // expose for derping around in console
+  api.export('PersistentSession', ['client']);
+  api.export('ReactiveDict', ['client']);
+
+  api.addFiles("tests/client/persistent_session.js", "client");
 });

--- a/tests/client/persistent_session.js
+++ b/tests/client/persistent_session.js
@@ -1,0 +1,229 @@
+Tinytest.add("defaults to temporary", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  test.equal('temporary', TestSession.default_method);
+});
+
+// this isnt testing anything yet...
+Tinytest.add("alternate mode", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  // TODO: This should probably be a reactive var, just for sanity now
+  TestSession.default_method = 'authenticated';
+  test.equal('authenticated', TestSession.default_method);
+
+  // reset to default
+  TestSession.default_method = 'temporary';
+  test.equal('temporary', TestSession.default_method);
+});
+
+Tinytest.add("clear all keys", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  test.equal(_.keys(TestSession._dict.keys).length, 0);
+
+  TestSession.set('foobar', 'woo');
+  var result = TestSession.get('foobar');
+  test.equal('woo', result);
+
+  test.equal(_.keys(TestSession._dict.keys).length, 1);
+
+  TestSession.clear();
+
+  test.equal(_.keys(TestSession._dict.keys).length, 0);
+
+  var result = TestSession.get('foobar');
+  test.equal(undefined, result);
+});
+
+Tinytest.add("clear single key", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  test.equal(_.keys(TestSession._dict.keys).length, 0);
+
+  TestSession.set('foobar', 'woo');
+  var result = TestSession.get('foobar');
+  test.equal('woo', result);
+
+  TestSession.set('barfoo', 'oow');
+  var result = TestSession.get('barfoo');
+  test.equal('oow', result);
+
+  test.equal(_.keys(TestSession._dict.keys).length, 2);
+
+  TestSession.clear('foobar');
+
+  test.equal(_.keys(TestSession._dict.keys).length, 1);
+
+  var result = TestSession.get('foobar');
+  test.equal(undefined, result);
+
+  var result = TestSession.get('barfoo');
+  test.equal('oow', result);
+});
+
+Tinytest.add("clear multiple keys", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  test.equal(_.keys(TestSession._dict.keys).length, 0);
+
+  TestSession.set('foobar', 'woo');
+  var result = TestSession.get('foobar');
+  test.equal('woo', result);
+
+  TestSession.set('barfoo', 'oow');
+  var result = TestSession.get('barfoo');
+  test.equal('oow', result);
+
+  test.equal(_.keys(TestSession._dict.keys).length, 2);
+
+  TestSession.clear(undefined, ['foobar', 'barfoo']);
+
+  test.equal(_.keys(TestSession._dict.keys).length, 0);
+
+  var result = TestSession.get('foobar');
+  test.equal(undefined, result);
+
+  var result = TestSession.get('barfoo');
+  test.equal(undefined, result);
+});
+
+
+Tinytest.add("gets undefined", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  var result = TestSession.get('foobar');
+  test.equal(void 0, result);
+});
+
+Tinytest.add("sets & gets", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  // set never returns anything although it probably should...
+  var result = TestSession.set('something', 'amazing');
+  test.equal(void 0, result);
+  // did it set?
+  result = TestSession.get('something');
+  test.equal('amazing', result);
+});
+
+Tinytest.add("sets defaults", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  // set never returns anything although it probably should...
+  var result = TestSession.setDefault('something', 'amazing');
+  test.equal(void 0, result);
+
+  // did it set?
+  result = TestSession.get('something');
+  test.equal('amazing', result);
+});
+
+Tinytest.add("sets defaults with an object", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  // set never returns anything although it probably should...
+  var result = TestSession.setDefault({ something: 'amazing', foobar: 'awesome'});
+  test.equal(void 0, result);
+
+  // did it set?
+  result = TestSession.get('something');
+  test.equal('amazing', result);
+
+  result = TestSession.get('foobar');
+  test.equal('awesome', result);
+});
+
+Tinytest.add("sets defaults but doesn't change if set", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  // set never returns anything although it probably should...
+  TestSession.set('something', 'amazing');
+
+  var result = TestSession.setDefault('something', 'awesome');
+  test.equal(void 0, result);
+
+  // did it set?
+  result = TestSession.get('something');
+  test.equal('amazing', result);
+});
+
+Tinytest.add("multiple sessions don't effect each other (never cross the streams)", function(test) {
+  var TestSessionFoo = new PersistentSession(Random.id());
+  var TestSessionBar = new PersistentSession(Random.id());
+
+  TestSessionFoo.set('something', 'amazing');
+  var result = TestSessionFoo.get('something');
+  test.equal('amazing', result);
+
+  TestSessionBar.set('something', 'awesome');
+  var result = TestSessionBar.get('something');
+  test.equal('awesome', result);
+
+  var result = TestSessionFoo.get('something');
+  test.equal('amazing', result);
+});
+
+
+Tinytest.add("store gets persisted value", function(test) {
+  var dictName = Random.id();
+  amplify.store(dictName + 'foo', EJSON.stringify("awesome"));
+
+  var TestSession = new PersistentSession(dictName);
+  var result = TestSession.get('foo');
+  test.equal('awesome', result);
+});
+
+
+Tinytest.add("setDefaultPersistent sets with an object", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  TestSession.setDefaultPersistent({ 
+    'id': 'foobarid', 
+    'room_id': 'foobarroomid'
+  });
+
+  var result = TestSession.get('id');
+  test.equal('foobarid', result);
+
+  var result = TestSession.get('room_id');
+  test.equal('foobarroomid', result);
+
+});
+
+Tinytest.add("setDefaultPersistent only sets unset keys (gh #32)", function(test) {
+  var TestSession = new PersistentSession(Random.id());
+
+  TestSession.set('room_id', 'awesome');
+  var result = TestSession.get('room_id');
+  test.equal('awesome', result);
+
+  TestSession.setDefaultPersistent({ 
+    'id': 'foobarid', 
+    'room_id': 'foobarroomid'
+  });
+
+  var result = TestSession.get('id');
+  test.equal('foobarid', result);
+
+  var result = TestSession.get('room_id');
+  test.equal('awesome', result);
+
+});
+
+
+Tinytest.add("setDefaultPersistent should not override an existing persisted value", function(test) {
+  var dictName = Random.id();
+  amplify.store(dictName + 'foo', EJSON.stringify("awesome"));
+
+  var TestSession = new PersistentSession(dictName);
+
+  var result = TestSession.get('foo');
+  test.equal('awesome', result);
+
+  TestSession.setDefaultPersistent('foo', 'foobarid');
+
+  var result = TestSession.get('foo');
+  test.equal('awesome', result);
+});
+

--- a/tests/client/persistent_session.js
+++ b/tests/client/persistent_session.js
@@ -227,3 +227,49 @@ Tinytest.add("setDefaultPersistent should not override an existing persisted val
   test.equal('awesome', result);
 });
 
+
+Tinytest.add("equals works", function(test) {
+  var dictName = Random.id();
+  amplify.store(dictName + 'foo', EJSON.stringify("awesome"));
+
+  var TestSession = new PersistentSession(dictName);
+
+  var result = TestSession.get('foo');
+  test.equal('awesome', result);
+
+  var result = TestSession.equals('foo', 'awesome');
+  test.equal(true, result);
+});
+
+Tinytest.add("all works", function(test) {
+  var dictName = Random.id();
+  // default the session with some data before creating it
+  amplify.store(dictName + 'foo', EJSON.stringify("awesome"));
+  // since we set foo, we'll also need it's key to be set to `set` is called 
+  // and it ends up in the `dict.keys`
+  amplify.store('__PSKEYS__' + dictName, ['foo']);
+
+  var TestSession = new PersistentSession(dictName);
+
+  var result = TestSession.get('foo');
+  test.equal('awesome', result);
+
+  TestSession.set('bar', 'thing');
+  var result = TestSession.get('bar');
+  test.equal('thing', result);
+
+  TestSession.setDefaultPersistent('foobar', 'stuff');
+  TestSession.setAuth('foobarfoo', 'fact');
+  TestSession.setPersistent('barfoobar', 'entity');
+
+  var result = TestSession.all();
+
+  test.equal({
+    "foo"       : "awesome",
+    "bar"       : "thing",
+    "foobar"    : "stuff",
+    "foobarfoo" : "fact",
+    "barfoobar" : "entity"
+  }, result);
+});
+


### PR DESCRIPTION
Refactors `persistent-session` to make it more testable, you can run them directly from the package directory: `meteor test-packages ./`, also bumps the version to 0.4.0, and makes best attempts to resolve existing issues:

re: #9

Rather then monkey patching `Meteor.logout`, we now use `Tracker.autorun`, I think it's best to avoid patching core methods.

re: #24 

This seems like a namespace issue with `amplify.store`, there is some good news and bad news here.

The good news is you can namespace a persistent session now: `new PersistentSession("somename")`. The bad news is for `Session` we don't use a unique key (to save from migrating/upgrading Sessions), so for instance if a package stores `id` with `amplify.store` and the user/dev attempts to `Session.set('id', 'thing')` there is potential for a conflict, although low. We could add a migration/upgrade step to allow Session to use a unique key which would lower the potential for conflicts

re: #31 

I can't reproduce the issue, but I added a test case: https://github.com/RobertLowe/meteor-persistent-session/blob/polish-persistent-sessions/tests/client/persistent_session.js#L215-L228 which is able to get a persisted value without any weird junk

re: #32 

I can't reproduce the issue but it seems fine, but I did add a test cases: https://github.com/RobertLowe/meteor-persistent-session/blob/polish-persistent-sessions/tests/client/persistent_session.js#L178-L212

Can someone verify?

---


Cheers :smile:

