### PR TITLE
Do not stringify value before saving

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -38,17 +38,17 @@ Session.store = function _psStore(type, key, value) {
       value = null;
 
     } else if (type=='persistent') {
-      this.psKeys[key] = EJSON.stringify(value);
+      this.psKeys[key] = EJSON.toJSONValue(value);
       this.psKeyList = _.union(this.psKeyList, [key]);
 
     } else if (type=='authenticated') {
-      this.psaKeys[key] = EJSON.stringify(value);
+      this.psaKeys[key] = EJSON.toJSONValue(value);
       this.psaKeyList = _.union(this.psaKeyList, [key]);
     }
 
     amplify.store('__PSKEYS__', this.psKeyList);
     amplify.store('__PSAKEYS__', this.psaKeyList);
-    amplify.store(key, EJSON.stringify(value));
+    amplify.store(key, EJSON.toJSONValue(value));
   }
 
 };
@@ -60,7 +60,7 @@ Session.get = function _psGet(key) {
   var psVal;
   var unparsedPsVal = Session.store('get', key);
   if (unparsedPsVal !== undefined) {
-    psVal = EJSON.parse(Session.store('get', key));
+    psVal = EJSON.fromJSONValue(Session.store('get', key));
   }
   /*
    * We can't do `return psVal || val;` here, as when psVal = undefined and
@@ -220,7 +220,7 @@ function migrateToEJSON() {
 
   _.each([psKeyList, psaKeyList], function(list) {
     _.each(list, function(key) {
-      amplify.store(key, EJSON.stringify(amplify.store(key)));
+      amplify.store(key, EJSON.toJSONValue(amplify.store(key)));
     });
   });
 


### PR DESCRIPTION
Hi,

The amplify library JSON stringifies the value before putting it into storage (https://github.com/mikehostetler/amplify/blob/master/src/store.js#L210-L212). 

This library also JSON stringifies the value with `EJSON.stringify` - This means the value gets stringified twice and causes escaping issues (https://github.com/okgrow/meteor-persistent-session/issues/31). 

We can instead just use `EJSON.toJSONValue` to still parse EJSON values correctly and then let the amplify library deal with the stringification.