### PR TITLE
Migration from 3.x to 4.x

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -97,14 +97,16 @@ PersistentSession = function (dictName) {
       _.each(list, function(key) {
         var invalid = false;
         try {
-          EJSON.parse(amplify.store(self._dictName+key));
+          EJSON.parse(EJSON.parse(amplify.store(self._dictName+key)));
         } catch (error) {
           //The data is already in the format that we expect
           //Unfortunately there is no EJSON.canParse method
           invalid = true;
         }
         if (!invalid) {
-          amplify.store(self._dictName+key, EJSON.toJSONValue(EJSON.parse(amplify.store(self._dictName+key))));
+          var parsed = EJSON.parse(EJSON.parse(amplify.store(self._dictName+key)));
+          var jsoned = EJSON.toJSONValue(parsed);
+          amplify.store(self._dictName+key, jsoned);
         }
       });
     });

--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -69,7 +69,7 @@ PersistentSession = function (dictName) {
    * Converts previously stored values into EJSON compatible formats.
    */
   function migrateToEJSON() {
-    if (amplify.store('__PSDATAVERSION__' + self._dictName) >= PSA_DATA_VERSION) {
+    if (amplify.store('__PSDATAVERSION__' + self._dictName) >= 1) {
       return;
     }
 
@@ -97,14 +97,14 @@ PersistentSession = function (dictName) {
       _.each(list, function(key) {
         var invalid = false;
         try {
-          EJSON.parse(EJSON.parse(amplify.store(self._dictName+key)));
+          EJSON.parse(amplify.store(self._dictName+key));
         } catch (error) {
           //The data is already in the format that we expect
           //Unfortunately there is no EJSON.canParse method
           invalid = true;
         }
         if (!invalid) {
-          var parsed = EJSON.parse(EJSON.parse(amplify.store(self._dictName+key)));
+          var parsed = EJSON.parse(amplify.store(self._dictName+key));
           var jsoned = EJSON.toJSONValue(parsed);
           amplify.store(self._dictName+key, jsoned);
         }

--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -39,9 +39,13 @@ PersistentSession = function (dictName) {
 
   /*
    * Used to determine if we need to migrate how the data is stored.
-   * Each time the data format changes, increment this number.
+   * Each time the data format changes, change this number.
+   *
+   * It should match the current major + minor version:
+   * EG: 0.3 = 3, 1.2 = 12, 2.0 = 20, or for 0.3.x: 3, or 1.x: 10
+   *
    */
-  var PSA_DATA_VERSION = 1;
+  var PSA_DATA_VERSION = 4;
 
   // === INITIALIZE KEY TRACKING ===
   this.psKeys     = {};
@@ -78,8 +82,35 @@ PersistentSession = function (dictName) {
       });
     });
 
-    amplify.store('__PSDATAVERSION__' + self._dictName, PSA_DATA_VERSION);
+    amplify.store('__PSDATAVERSION__' + self._dictName, 2);
   };
+
+  function migrate3Xto4X() {
+    if (amplify.store('__PSDATAVERSION__' + self._dictName) >= PSA_DATA_VERSION) {
+      return;
+    }
+
+    var psKeyList = amplify.store('__PSKEYS__' + self._dictName);
+    var psaKeyList = amplify.store('__PSAKEYS__' + self._dictName);
+
+    _.each([psKeyList, psaKeyList], function(list) {
+      _.each(list, function(key) {
+        var invalid = false;
+        try {
+          EJSON.parse(amplify.store(self._dictName+key));
+        } catch (error) {
+          //The data is already in the format that we expect
+          //Unfortunately there is no EJSON.canParse method
+          invalid = true;
+        }
+        if (!invalid) {
+          amplify.store(self._dictName+key, EJSON.toJSONValue(EJSON.parse(amplify.store(self._dictName+key))));
+        }
+      });
+    });
+
+    amplify.store('__PSDATAVERSION__' + self._dictName, 4);
+  }
 
   if (Meteor.isClient) {
 
@@ -88,6 +119,7 @@ PersistentSession = function (dictName) {
       var val;
 
       migrateToEJSON();
+      migrate3Xto4X();
 
       // persistent data
       var psList = amplify.store('__PSKEYS__' + self._dictName);

--- a/tests/client/persistent_session.js
+++ b/tests/client/persistent_session.js
@@ -300,19 +300,25 @@ Tinytest.add("all works", function(test) {
 });
 
 Tinytest.add("updates from 3.x to 4.x", function(test) {
-  // Set up 3.x-format keys/values
   var dictName = Random.id();
-  amplify.store(dictName + 'foo', '[]'); // 3.x saved it as a string
-  amplify.store(dictName + 'bar', []); // new 4.x data format, migration shouldn't clobber it
-  amplify.store(dictName + 'obj1', EJSON.stringify({ foo: "bar" }));
-  amplify.store(dictName + 'obj2', { foo2: "bar2" });
-  amplify.store('__PSKEYS__' + dictName, ['foo', 'bar', 'obj1', 'obj2']);
+  localStorage.clear();
+  // Set up 3.x-format keys/values
+  localStorage['__amplify__' + dictName + 'foo'] = '{"data":"[]","expires":null}';
+  localStorage['__amplify__' + dictName + 'bar'] = '{"data":"\\"noodol\\"","expires":null}';
+  localStorage['__amplify__' + dictName + 'obj'] = '{"data":"{\\"obj\\":\\"val\\"}","expires":null}';
+  // 4.x-format keys/values
+  localStorage['__amplify__' + dictName + 'foo4'] = '{"data":[],"expires":null}';
+  localStorage['__amplify__' + dictName + 'bar4'] = '{"data":"noodol","expires":null}';
+  localStorage['__amplify__' + dictName + 'obj4'] = '{"data":{"obj":"val"},"expires":null}';
+  amplify.store('__PSKEYS__' + dictName, ['foo', 'bar', 'obj', 'foo4', 'bar4', 'obj4']);
   amplify.store('__PSDATAVERSION__' + dictName, 1);
 
   var TestSession = new PersistentSession(dictName);
-  test.equal(TestSession.get('foo'), []);
-  test.equal(TestSession.get('bar'), []);
-  test.equal(TestSession.get('obj1'), { foo: "bar" });
-  test.equal(TestSession.get('obj2'), { foo2: "bar2" });
   test.equal(amplify.store('__PSDATAVERSION__' + dictName), 4);
+  test.equal(TestSession.get('foo'), []);
+  test.equal(TestSession.get('bar'), "noodol");
+  test.equal(TestSession.get('obj'), { obj: "val" });
+  test.equal(TestSession.get('foo4'), []);
+  test.equal(TestSession.get('bar4'), "noodol");
+  test.equal(TestSession.get('obj4'), { obj: "val" });
 });


### PR DESCRIPTION
Add a migration to update the data format from 3.x to 4.x.

We check each entry, and if it can be parsed with EJSON.parse, we parse it, and then store it again using EJSON.toJSONValue

Fixes #37 and #45

@pauldowman 