### PR TITLE
Swap to double quotes for settings.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ To define the default type for session variables, set `persistent_session.defaul
 {
   "public": {
     "persistent_session": {
-      "default_method": 'your-preferred-type'
+      "default_method": "your-preferred-type"
     }
   }
 }


### PR DESCRIPTION
Using single quotes throws an error when trying to load the settings.json file.